### PR TITLE
Add Cronitor monitoring using nat-monitor v1.1.0

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -41,5 +41,13 @@ suites:
           # aws_access_key_id: AWS_ACCESS_KEY_ID
           # aws_secret_access_key: AWS_SECRET_ACCESS_KEY
           # aws_url: http://192.168.1.191:5000
+          monitor_enabled: true
+        monitor:
+          api_urls:
+            us-east-1b:
+              run: http://example.com/run
+              complete: http://example.com/complete
+              fail: http://example.com/fail
       ec2:
         instance_id: i-00000003
+        placement_availability_zone: us-east-1b

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,5 +30,13 @@ suites:
           aws_access_key_id: AWS_ACCESS_KEY_ID
           aws_secret_access_key: AWS_SECRET_ACCESS_KEY
           aws_url: http://192.168.1.191:5000
+          monitor_enabled: true
+        monitor:
+          api_urls:
+            us-east-1b:
+              run: http://example.com/run
+              complete: http://example.com/complete
+              fail: http://example.com/fail
       ec2:
         instance_id: i-00000003
+        placement_availability_zone: us-east-1b

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default['nat']['yaml']['mocking'] = true
+default['nat']['yaml']['monitor_enabled'] = false

--- a/recipes/ha.rb
+++ b/recipes/ha.rb
@@ -11,7 +11,7 @@ if nat_instances.count > 2
 
   gem_package 'nat-monitor' do
     action :upgrade
-    version '1.0.9'
+    version '3.0.1'
   end
 
   log 'Other instances found.  Setting up the NAT Monitor.' do
@@ -45,6 +45,15 @@ if nat_instances.count > 2
         node.chef_environment,
         conn_opts
       )
+  end
+
+  if node['nat']['yaml']['monitor_enabled']
+    az = node['ec2']['placement_availability_zone']
+
+    %w(begin success fail).each do |status|
+      node.set['nat']['yaml']['monitor_urls'][status] =
+        node['nat']['monitor']['api_urls'][az]
+    end
   end
 
   file '/etc/nat_monitor.yml' do

--- a/test/integration/cloud/serverspec/ha_spec.rb
+++ b/test/integration/cloud/serverspec/ha_spec.rb
@@ -10,4 +10,15 @@ describe 'et_nat::ha' do
     it { is_expected.to be_running }
     its(:args) { should match(/nat-monitor/) }
   end
+
+  describe file '/etc/nat_monitor.yml' do
+    describe '#content' do
+      subject { super().content }
+      it { is_expected.to include 'mocking: true' }
+      it { is_expected.to include 'route_table_id: rtb-a1b2c3d4' }
+      it { is_expected.to include 'run: http://example.com/run' }
+      it { is_expected.to include 'complete: http://example.com/complete' }
+      it { is_expected.to include 'fail: http://example.com/fail' }
+    end
+  end
 end

--- a/test/integration/default/serverspec/ha_spec.rb
+++ b/test/integration/default/serverspec/ha_spec.rb
@@ -10,4 +10,18 @@ describe 'et_nat::ha' do
     it { is_expected.to be_running }
     its(:args) { should match(/nat-monitor/) }
   end
+
+  describe file '/etc/nat_monitor.yml' do
+    describe '#content' do
+      subject { super().content }
+      it { is_expected.to include 'mocking: true' }
+      it { is_expected.to include 'aws_access_key_id: AWS_ACCESS_KEY_ID' }
+      it { is_expected.to include 'aws_secret_access_key: AWS_SECRET_ACCESS_KEY' }
+      it { is_expected.to include 'aws_url: http://192.168.1.191:5000' }
+      it { is_expected.to include 'route_table_id: rtb-a1b2c3d4' }
+      it { is_expected.to include 'run: http://example.com/run' }
+      it { is_expected.to include 'complete: http://example.com/complete' }
+      it { is_expected.to include 'fail: http://example.com/fail' }
+    end
+  end
 end

--- a/test/integration/nodes/nat1.json
+++ b/test/integration/nodes/nat1.json
@@ -18,5 +18,8 @@
     "roles": [
       "nat"
     ]
-  }
+  },
+  "run_list": [
+    "recipe[et_nat]"
+  ]
 }

--- a/test/integration/nodes/nat2.json
+++ b/test/integration/nodes/nat2.json
@@ -7,16 +7,16 @@
     }
   },
   "automatic": {
+    "ipaddress": "192.168.33.12",
+    "ec2": {
+      "instance_id": "i-00000002"
+    },
     "fqdn": "nat2.vagrantup.com",
     "recipes": [
       "et_nat"
     ],
     "roles": [
       "nat"
-    ],
-    "ipaddress": "192.168.33.12",
-    "ec2": {
-      "instance_id": "i-00000002"
-    }
+    ]
   }
 }

--- a/test/integration/nodes/nat2.json
+++ b/test/integration/nodes/nat2.json
@@ -18,5 +18,8 @@
     "roles": [
       "nat"
     ]
-  }
+  },
+  "run_list": [
+    "recipe[et_nat]"
+  ]
 }

--- a/test/integration/nodes/nat3.json
+++ b/test/integration/nodes/nat3.json
@@ -18,5 +18,8 @@
     "roles": [
       "nat"
     ]
-  }
+  },
+  "run_list": [
+    "recipe[et_nat]"
+  ]
 }

--- a/test/integration/nodes/nat3.json
+++ b/test/integration/nodes/nat3.json
@@ -7,16 +7,16 @@
     }
   },
   "automatic": {
+    "ipaddress": "192.168.33.11",
+    "ec2": {
+      "instance_id": "i-00000003"
+    },
     "fqdn": "nat3.vagrantup.com",
     "recipes": [
       "et_nat"
     ],
     "roles": [
       "nat"
-    ],
-    "ipaddress": "192.168.33.11",
-    "ec2": {
-      "instance_id": "i-00000003"
-    }
+    ]
   }
 }


### PR DESCRIPTION
Biggest change here is in 0ef0060, which is better understood by looking at [nat-monitor’s v1.0.9…v1.1.0 changest](https://github.com/evertrue/nat-monitor/compare/v1.0.9...v1.1.0).